### PR TITLE
[show/tests] Add support for "show run isis"

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -22,7 +22,8 @@ from .isis_frr_input.isis_frr_test_vector import(
     mock_show_isis_neighbors,
     mock_show_isis_database,
     mock_show_isis_hostname,
-    mock_show_isis_interface
+    mock_show_isis_interface,
+    mock_show_run_isis
     )
 from . import config_int_ip_common
 import utilities_common.constants as constants
@@ -395,7 +396,10 @@ def setup_single_isis_instance(request):
     elif request.param.startswith('isis_interface') or \
             request.param.startswith('isis_interface'):
         bgp_util.run_bgp_command = mock.MagicMock(
-            return_value=mock_show_isis_interface(request))       
+            return_value=mock_show_isis_interface(request))
+    elif request.param.startswith('show_run_isis'):
+        bgp_util.run_bgp_command = mock.MagicMock(
+            return_value=mock_show_run_isis(request))    
     yield
 
     bgp_util.run_bgp_command = _old_run_bgp_command

--- a/tests/isis_frr_input/isis_frr_test_vector.py
+++ b/tests/isis_frr_input/isis_frr_test_vector.py
@@ -452,6 +452,53 @@ def mock_show_isis_interface(request):
     else:
         return ""
 
+show_run_isis_output = \
+"""Building configuration...
+
+Current configuration:
+!
+frr version 8.2.2
+frr defaults traditional
+hostname vlab-01
+log syslog informational
+log facility local4
+no service integrated-vtysh-config
+!
+password zebra
+enable password zebra
+!
+interface PortChannel101
+ ip router isis 1
+ ipv6 router isis 1
+ isis network point-to-point
+exit
+!
+router isis 1
+ is-type level-2-only
+ net 49.0001.1720.1700.0002.00
+ lsp-mtu 1383
+ lsp-timers level-1 gen-interval 30 refresh-interval 900 max-lifetime 1200
+ lsp-timers level-2 gen-interval 30 refresh-interval 305 max-lifetime 900
+ log-adjacency-changes
+exit
+!
+end
+"""
+
+show_run_isis_invalid_help_output = \
+"""Usage: isis [OPTIONS]
+Try "isis --help" for help.
+
+Error: Got unexpected extra argument (?)
+"""
+
+def mock_show_run_isis(request):
+    if request.param == 'show_run_isis_output':
+        return show_run_isis_output
+    elif request.param == 'show_run_isis_invalid_help_output':
+        return show_run_isis_invalid_help_output
+    else:
+        return ""
 
 testData = {
     'isis_neighbors': {
@@ -553,5 +600,15 @@ testData = {
         'args': ['sonic1'],
         'rc': 2,
         'rc_output': isis_interface_unknown_ifname_output
+    },
+    'show_run_isis': {
+        'args': [],
+        'rc': 0,
+        'rc_output': show_run_isis_output
+    },
+    'show_run_isis_invalid_help': {
+        'args': ['?'],
+        'rc': 2,
+        'rc_output': show_run_isis_invalid_help_output
     },
 }

--- a/tests/isis_frr_test.py
+++ b/tests/isis_frr_test.py
@@ -125,3 +125,24 @@ class TestIsisInterface(object):
         show = setup_isis_commands
         exec_cmd = show.cli.commands["isis"].commands["interface"]
         executor(test_vector, show, exec_cmd)
+
+
+class TestShowRunIsis(object):
+
+    @classmethod
+    def setup_class(cls):
+        print("SETUP")
+
+    @pytest.mark.parametrize('setup_single_isis_instance, test_vector',
+                             [
+                                 ('show_run_isis_output', 'show_run_isis'),
+                                 ('show_run_isis_invalid_help_output', 'show_run_isis_invalid_help')
+                             ],
+                             indirect=['setup_single_isis_instance'])
+    def test_show_run_isis(self,
+                           setup_isis_commands,
+                           setup_single_isis_instance,
+                           test_vector):
+        show = setup_isis_commands
+        exec_cmd = show.cli.commands["runningconfiguration"].commands["isis"]
+        executor(test_vector, show, exec_cmd)


### PR DESCRIPTION
Signed-off-by: ideleon@microsoft.com

<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did

#### How I did it

#### How to verify it

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

```
admin@vlab-01:/usr/local/lib/python3.9/dist-packages/show$ show run isis
Building configuration...

Current configuration:
!
frr version 8.2.2
frr defaults traditional
hostname vlab-01
log syslog informational
log facility local4
no service integrated-vtysh-config
!
password zebra
enable password zebra
!
interface PortChannel101
 ip router isis 1
 ipv6 router isis 1
 isis network point-to-point
exit
!
router isis 1
 is-type level-2-only
 net 49.0001.1720.1700.0002.00
 lsp-mtu 1383
 lsp-timers level-1 gen-interval 30 refresh-interval 900 max-lifetime 1200
 lsp-timers level-2 gen-interval 30 refresh-interval 305 max-lifetime 900
 log-adjacency-changes
exit
!
end

admin@vlab-01:/usr/local/lib/python3.9/dist-packages/show$ show run isis --config_db
{
    "ISIS_GLOBAL": {
        "1": {
            "dynamic-hostname": "true",
            "level-capability": "level-2",
            "log-adjacency-changes": "true",
            "lsp-mtu-size": "1383",
            "net": "49.0001.1720.1700.0002.00"
        }
    },
    "ISIS_LEVEL": {
        "1|level-2": {
            "lsp-maximum-lifetime": "350",
            "lsp-refresh-interval": "305"
        }
    },
    "ISIS_INTERFACE": {
        "1|PortChannel101": {
            "hello-padding": "false",
            "ifname": "PortChannel101",
            "instance": "1",
            "ipv4-routing-instance": "1",
            "ipv6-routing-instance": "1",
            "network-type": "POINT_TO_POINT_NETWORK"
        }
    }
}
admin@vlab-01:/usr/local/lib/python3.9/dist-packages/show$ 
```
